### PR TITLE
Run block hooks within instance

### DIFF
--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -50,7 +50,7 @@ module Hooks
         if callback.kind_of? Symbol
           scope.send(callback, *args)
         else
-          callback.call(*args)
+          scope.instance_exec(*args, &callback)
         end 
       end
     end

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -75,6 +75,12 @@ class HooksTest < Test::Unit::TestCase
         
         assert_equal [2, 0], @mum.executed
       end
+
+      should "execute block hooks within instance" do
+        @mum.class.after_eight { executed << :c }
+        @mum.run_hook(:after_eight)
+        assert_equal [:c], @mum.executed
+      end
     end
     
     context "in class context" do


### PR DESCRIPTION
As discussed in #5 using instance exec to run block hooks within context of instance
