### PR TITLE
Make `define_hook` take multiple hook names

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,9 +20,11 @@ Let's take... a cat.
   class Cat
     include Hooks
 
-    define_hook :after_dinner
+    define_hooks :before_dinner, :after_dinner
 
 Now you can add callbacks to your hook declaratively in your class.
+
+    before_dinner :wash_paws
 
     after_dinner do
       puts "Ice cream for #{self}!"

--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -5,11 +5,12 @@ require "hooks/inheritable_attribute"
 # Example:
 #
 #   class CatWidget < Apotomo::Widget
-#     define_hook :after_dinner
+#     define_hooks :before_dinner, :after_dinner
 #
 # Now you can add callbacks to your hook declaratively in your class.
 #
-#     after_dinner do puts "Ice cream!" end
+#     before_dinner :wash_paws
+#     after_dinner { puts "Ice cream!" }
 #     after_dinner :have_a_desert   # => refers to CatWidget#have_a_desert
 # 
 # Running the callbacks happens on instances. It will run the block and #have_a_desert from above.
@@ -24,12 +25,15 @@ module Hooks
   end
   
   module ClassMethods
-    def define_hook(name)
-      accessor_name = "_#{name}_callbacks"
-      
-      setup_hook_accessors(accessor_name)
-      define_hook_writer(name, accessor_name)
+    def define_hooks(*names)
+      names.each do |name|
+        accessor_name = "_#{name}_callbacks"
+        
+        setup_hook_accessors(accessor_name)
+        define_hook_writer(name, accessor_name)
+      end
     end
+    alias_method :define_hook, :define_hooks
     
     # Like Hooks#run_hook but for the class. Note that +:callbacks+ must be class methods.
     #

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -29,6 +29,12 @@ class HooksTest < Test::Unit::TestCase
       @klass.after_eight :dine
       assert_equal [:dine], @klass.callbacks_for_hook(:after_eight)
     end
+
+    should "accept multiple hook names" do
+      @mum.class.define_hooks :before_ten, :after_ten
+      assert_equal [], @klass.callbacks_for_hook(:before_ten)
+      assert_equal [], @klass.callbacks_for_hook(:after_ten)
+    end
   
     context "creates a public writer for the hook that" do
       should "accepts method names" do


### PR DESCRIPTION
This is a patch to make `define_hook` more useful. In classes with
multiple hooks, defining each hook on a separate line can take up a lot
of space. For single hooks, `define_hook` is still available for
semantics. However, for multiple hooks, you can define them all with the
same call:

`define_hooks :before_dinner, :after_dinner, :another_hook`

Signed-off-by: David Celis david@davidcelis.com
