### PR TITLE
return hook results in run_hook_for

### DIFF
--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -47,7 +47,7 @@ module Hooks
     end    
     
     def run_hook_for(name, scope, *args)
-      callbacks_for_hook(name).each do |callback|
+      callbacks_for_hook(name).map do |callback|
         if callback.kind_of? Symbol
           scope.send(callback, *args)
         else

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -87,6 +87,15 @@ class HooksTest < Test::Unit::TestCase
         @mum.run_hook(:after_eight)
         assert_equal [:c], @mum.executed
       end
+
+      should "return callback results in order" do
+        @mum.class.after_eight { :dinner_out }
+        @mum.class.after_eight { :party_hard }
+        @mum.class.after_eight { :taxi_home }
+
+        results = @mum.run_hook(:after_eight)
+        assert_equal [:dinner_out, :party_hard, :taxi_home], results
+      end
     end
     
     context "in class context" do
@@ -141,7 +150,7 @@ class HooksTest < Test::Unit::TestCase
         end
       end.new
       
-      assert_equal [:take_shower, :have_dinner], @kid.run_hook(:after_eight)
+      assert_equal [:take_shower, :have_dinner], @kid.class.callbacks_for_hook(:after_eight)
     end
   end
 end


### PR DESCRIPTION
Precedently, `run_hook_for` returned the callback list, which can also be obtained using `callbacks_for_hook`. One test relied on this behavior and had to be adapted.

Since this was previously undocumented behavior, I don't believe it qualifies as an API breakage.

It is more convenient than relying on handmade setup accumulator (like `@executed` in tests), but I didn't want to refactor all the tests to demonstrate it - although I'd be keen to do it if you deem it appropriate.

Hope it gets in :)
