### PR TITLE
Updating behavior for string based hooks

### DIFF
--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -54,7 +54,7 @@ module Hooks
     end
 
     def run_hook_for(name, scope, *args)
-      _hooks[name].run(scope, *args)
+      callbacks_for_hook(name).run(scope, *args)
     end
 
     # Returns the callbacks for +name+. Handy if you want to run the callbacks yourself, say when
@@ -69,12 +69,12 @@ module Hooks
     #
     # would run callbacks in the object _instance_ context, passing +self+ as block parameter.
     def callbacks_for_hook(name)
-      _hooks[name]
+      _hooks[name.to_sym]
     end
 
   private
     def setup_hook(name, options)
-      _hooks[name] = Hook.new(options)
+      _hooks[name.to_sym] = Hook.new(options)
       define_hook_writer(name)
     end
 

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -25,6 +25,13 @@ class HooksTest < MiniTest::Spec
       assert_equal [:dine], klass.callbacks_for_hook(:after_eight)
     end
 
+    it 'symbolizes strings when defining a hook' do
+      subject.class.define_hooks :before_one, 'after_one'
+      assert_equal [], klass.callbacks_for_hook(:before_one)
+      assert_equal [], klass.callbacks_for_hook(:after_one)
+      assert_equal [], klass.callbacks_for_hook('after_one')
+    end
+
     it "accept multiple hook names" do
       subject.class.define_hooks :before_ten, :after_ten
       assert_equal [], klass.callbacks_for_hook(:before_ten)


### PR DESCRIPTION
This commit addresses the fact that `define_hook 'after_hello'` was
treated differently than `define_hook :after_hello`. In the hook writer
it would attempt to register as a symbol (`_hooks[:#{name}]`) but prior
to that call it was registered as `_hooks[name]`
