### PR TITLE
allow to optionally evaluate hook blocks in their initial context

### DIFF
--- a/lib/hooks/hook.rb
+++ b/lib/hooks/hook.rb
@@ -45,6 +45,10 @@ module Hooks
     end
 
     def <<(callback)
+      if callback.is_a?(Proc) && @options[:call_procs_in_original_context]
+        p = callback
+        callback = proc { |*args, &b| p.call(*args, &b) }
+      end
       super Uber::Options::Value.new(callback, :dynamic => true) # allows string and symbol method names.
     end
 

--- a/test/hook_test.rb
+++ b/test/hook_test.rb
@@ -9,6 +9,21 @@ class HookTest < MiniTest::Spec
 
     subject.to_a.map(&:to_sym).must_equal [:play_music, :drink_beer]
   end
+
+  it "evals the procs in the context of its argument" do
+    subject << proc { self }
+    obj = Object.new
+    subject.run(obj).must_equal [obj]
+  end
+
+  describe "the call_procs_in_original_context option" do
+    subject { Hooks::Hook.new(call_procs_in_original_context: true) }
+    it "calls the procs in its original context" do
+      subject << proc { self }
+      obj = Object.new
+      subject.run(obj).must_equal [self]
+    end
+  end
 end
 
 class ResultsTest < MiniTest::Spec


### PR DESCRIPTION
The current behaviour is to evaluate all hook callbacks in the
context of the receiving object. This allows to define that certain
hooks should be evaluated directly in the context of the block.