### PR TITLE
allow to tune the hooks evaluation scope at definition time

### DIFF
--- a/test/hook_test.rb
+++ b/test/hook_test.rb
@@ -9,6 +9,32 @@ class HookTest < MiniTest::Spec
 
     subject.to_a.map(&:to_sym).must_equal [:play_music, :drink_beer]
   end
+
+  it "evals the procs in the context of its argument" do
+    subject << proc { self }
+    obj = Object.new
+    subject.run(obj).must_equal [obj]
+  end
+
+  describe "the scope option" do
+   it "passes the callback and the scope as arguments and evaluates on the returned scope" do
+      obj = Object.new
+      hook = Hooks::Hook.new(scope: lambda { |callback, scope| [[callback], [scope]] })
+      hook << :flatten
+      hook.run(obj = Object.new).must_equal [[hook.last, obj]]
+    end
+    it "uses a plain object as a static scope" do
+      scope = Object.new
+      hook = Hooks::Hook.new(scope: scope)
+      hook << lambda { self }
+      hook.run(Object.new).must_equal [scope]
+    end
+    it "evaluates procs in their definition context if nil is returned" do
+      hook = Hooks::Hook.new(scope: lambda { |callback, scope| scope if !callback.proc? })
+      hook << lambda { self }
+      hook.run(Object.new).must_equal [self]
+    end
+  end
 end
 
 class ResultsTest < MiniTest::Spec


### PR DESCRIPTION
The part of "returning nil for procs" needs https://github.com/apotonick/uber/pull/9

While the main goal of this commit is to provide a way to evaluate
blocks in their definition scope (instead of instance_exec'ing them
mandatorily), it is more flexible than that.

The simplest value for scope is a fixed object (e.g. a class)

    define_hook :myhook, scope: MyClass

Or a proc/lambda, which will be passed the callback and the scope
and should return the new scope. This can be used if e.g. you accept
all types of callback and want the procs to be evaluated in their
definition context (as opposed to hooks default behaviour of evaluating
them in the context of the receiver)

Getting the blocks evaluated in their definition scope is achieved
by returning nil for procs:

    define_hook :myhook, scope: lambda { |callback, scope| scope if !callback.proc? }

If you want all the callbacks to be evaluated in the context of a
sandbox:

    define_hook :myhook, scope: lambda { |callback, scope| Sandbox.new(scope) }