### PR TITLE
Clear error message when undefined hook

### DIFF
--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -52,6 +52,7 @@ module Hooks
     end
 
     def run_hook_for(name, scope, *args)
+      throw "No hook defined with name #{name}" if _hooks[name].nil?
       _hooks[name].run(scope, *args)
     end
 


### PR DESCRIPTION
I was confused when I saw `NoMethodError: undefined method 'run' for nil:NilClass` and this should help make it clear that this is because the hook name was not defined.
