### PR TITLE
Travis: install Bundler to get a green build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
This PR tries to fix the build on 1.9.3 by avoiding a very-old Bundler.